### PR TITLE
normpart fixes

### DIFF
--- a/finite_sum.c
+++ b/finite_sum.c
@@ -707,7 +707,7 @@ extern "C" {
 
 	  // compute the "cosine" and "sine" parts of the summand
 	  ept = exppart(n, X, x, intshift, g);
-	  npt = exp(normpart_phaseI(n, T, fracshift, g));
+	  npt = exp(normpart(n, T, fracshift, g));
 	  cpt = npt * cos(ept);
 	  spt = npt * sin(ept);
 	  deriv_prod(dpr, dpi, n, intshift, deriv_real, deriv_imag, nderivs, g);
@@ -778,7 +778,7 @@ extern "C" {
 
 	  // compute the "cosine" and "sine" parts of the summand
 
-	  npt = exp(normpart(n, T, fracshift, g));
+	  npt = exp(normpart_phaseI(n, T, fracshift, g));
 
 	  deriv_prod_phaseI(dpr, dpi, n, intshift, deriv_real, deriv_imag, nderivs, g);
 
@@ -904,7 +904,7 @@ extern "C" {
 
 	  // compute the "cosine" and "sine" parts of the summand
 
-	  npt = exp(normpart(n, T, fracshift, g));
+	  npt = exp(normpart_phaseI(n, T, fracshift, g));
 
 	  deriv_prod_phaseI(dpr, dpi, n, intshift, deriv_real, deriv_imag, nderivs, g);
 
@@ -1062,7 +1062,7 @@ extern "C" {
 
 	  n = S + k*g;
 
-	  npt = exp(normpart(n, T, fracshift, g));
+	  npt = exp(normpart_phaseI(n, T, fracshift, g));
 	  real_total_den += npt;
 
 	  for (int d = 0; d < numderivs; d++)
@@ -1258,7 +1258,7 @@ extern "C" {
 
 	  n = S + k*g;
 
-	  npt = exp(normpart(n, T, fracshift, g));
+	  npt = exp(normpart_phaseI(n, T, fracshift, g));
 
 	  for (int d = 0; d < numderivs; d++)
 	    {


### PR DESCRIPTION
Fixed the normpart calls to the respective phase functions. Plz verify if for you mode 0 matches the mode 1 and mode 2 theta function calcs as well (with derivative and without for real, respectively imag inputs).
